### PR TITLE
update(sdk): improve current methods and create getGroundPlacesFile

### DIFF
--- a/__tests__/groundplaces/autocomplete.spec.ts
+++ b/__tests__/groundplaces/autocomplete.spec.ts
@@ -337,4 +337,103 @@ describe('#autocomplete', () => {
       },
     ]);
   });
+
+  it('should returns only places that are StopGroup and StopCluster', () => {
+    const groundPlacesFiltered: GroundPlace[] = groundPlacesService.autocomplete('', [
+      AutocompleteFilter.STOP_GROUP,
+      AutocompleteFilter.STOP_CLUSTER,
+    ]);
+
+    expect(groundPlacesFiltered).toStrictEqual([
+      {
+        gpuid: 'c|FRstrasbou@u0ts2',
+        unique_name: 'strasbourg',
+        childs: ['g|FRststbi__@u0tkxd', 'g|FRstrasbou@u0tkru', 'g|FRstraroet@u0tkr3'],
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Strasbourg, Grand-Est, France',
+        longitude: 7.74815,
+        latitude: 48.583,
+        type: 'cluster',
+      },
+      {
+        gpuid: 'g|FRststbi__@u0tkxd',
+        childs: [],
+        name: 'Strasbourg, Strasbourg - Bischheim',
+        longitude: 7.719863,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.616228,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'g|FRstrasbou@u0tkru',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'flixbus',
+            name: 'Strasbourg',
+            latitude: 48.574179,
+            serviced: 'False',
+            company_id: 5,
+            longitude: 7.754266,
+            id: '23',
+          },
+        ],
+        name: 'Strasbourg',
+        longitude: 7.73417,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.58392,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'g|FRstraroet@u0tkr3',
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'vsc',
+            name: 'Strasbourg Roethig',
+            latitude: 48.569,
+            serviced: 'False',
+            company_id: 10,
+            longitude: 7.704,
+            id: 'FRBUK',
+          },
+        ],
+        name: 'Strasbourg Roethig',
+        longitude: 7.704,
+        serviced: 'False',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.569,
+        is_latest: true,
+        type: 'group',
+      },
+      {
+        gpuid: 'c|FRnaarto__@u0skg',
+        unique_name: 'nancy---tous-les-arrets',
+        childs: [],
+        serviced: 'True',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Nancy - Tous les arrêts, Grand Est, France',
+        longitude: 6.1444727044,
+        latitude: 48.6484863111,
+        type: 'cluster',
+      },
+    ]);
+  });
 });

--- a/__tests__/groundplaces/getGroundPlacesFile.spec.ts
+++ b/__tests__/groundplaces/getGroundPlacesFile.spec.ts
@@ -1,0 +1,50 @@
+import { GroundPlacesController } from '../../src/classes/groundplaces';
+import * as mockSmallGroundPlacesFile from '../../mocks/smallGroundPlacesFile.json';
+import { GroundPlacesFile } from '../../src/types';
+
+describe('#getGroundPlacesFile', () => {
+  const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+
+  it('should get the correct GroundPlacesFile', () => {
+    groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
+
+    expect(groundPlacesService.getGroundPlacesFile()).toStrictEqual({
+      'c|FRstrasbou@u0ts2': {
+        unique_name: 'strasbourg',
+        childs: ['g|FRststbi__@u0tkxd'],
+        serviced: 'True',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        is_latest: true,
+        name: 'Strasbourg, Grand-Est, France',
+        longitude: 7.74815,
+        latitude: 48.583,
+        type: 'cluster',
+      },
+      'g|FRststbi__@u0tkxd': {
+        childs: [
+          {
+            unique_name: null,
+            company_name: 'flixbus',
+            name: 'Strasbourg, Strasbourg - Bischheim',
+            latitude: 48.616228,
+            serviced: 'True',
+            company_id: 5,
+            longitude: 7.719863,
+            id: '19528',
+          },
+        ],
+        name: 'Strasbourg, Strasbourg - Bischheim',
+        longitude: 7.719863,
+        serviced: 'True',
+        has_been_modified: false,
+        warning: false,
+        country_code: 'fr',
+        latitude: 48.616228,
+        is_latest: true,
+        type: 'group',
+      },
+    });
+  });
+});

--- a/__tests__/groundplaces/updateStopCluster.spec.ts
+++ b/__tests__/groundplaces/updateStopCluster.spec.ts
@@ -98,4 +98,26 @@ describe('#updateStopCluster', () => {
       ),
     );
   });
+
+  it('should thrown an error if the new name of the StopCluster is empty', () => {
+    const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+
+    groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
+
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', {
+        name: '',
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error(
+        'You can\'t update the "cluster" named "Strasbourg, Grand-Est, France" because the new name defined is empty.',
+      ),
+    );
+  });
 });

--- a/__tests__/groundplaces/updateStopGroup.spec.ts
+++ b/__tests__/groundplaces/updateStopGroup.spec.ts
@@ -143,4 +143,26 @@ describe('#updateStopGroup', () => {
       ),
     );
   });
+
+  it('should thrown an error if the new name of the StopGroup is empty', () => {
+    const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+
+    groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
+
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.updateStopGroup('g|FRststbi__@u0tkxd', {
+        name: '',
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error(
+        'You can\'t update the "group" named "Strasbourg, Strasbourg - Bischheim" because the new name defined is empty.',
+      ),
+    );
+  });
 });

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -784,6 +784,14 @@ export class GroundPlacesController {
   }
 
   /**
+   * @description Get the GroundPlaces file.
+   * @returns {GroundPlacesFile}
+   */
+  public getGroundPlacesFile(): GroundPlacesFile {
+    return this.storageService.getGroundPlacesFile();
+  }
+
+  /**
    * @description Getter to retrieve the GroundPlaceActionHistory object.
    * @returns {GroundPlaceActionHistory[]}
    */

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -115,8 +115,8 @@ export class GroundPlacesController {
         }
 
         if (
-          (isFilterByStopGroupActive && place.type !== GroundPlaceType.GROUP) ||
-          (isFilterByStopClusterActive && place.type !== GroundPlaceType.CLUSTER) ||
+          (isFilterByStopGroupActive && !isFilterByStopClusterActive && place.type !== GroundPlaceType.GROUP) ||
+          (isFilterByStopClusterActive && !isFilterByStopGroupActive && place.type !== GroundPlaceType.CLUSTER) ||
           (isFilterByServicedActive && place.serviced !== GroundPlaceServiced.TRUE)
         ) {
           return;

--- a/src/classes/storage.ts
+++ b/src/classes/storage.ts
@@ -34,7 +34,12 @@ export class Storage {
       }),
     );
 
-    this.groundPlaces = groundPlaces;
+    // Clear GroundPlacesActionHistory on init
+    if (this.groundPlacesActionHistory.length) {
+      this.groundPlacesActionHistory = [];
+    }
+
+    this.setGroundPlaces(groundPlaces);
   }
 
   /**

--- a/src/classes/storage.ts
+++ b/src/classes/storage.ts
@@ -166,6 +166,12 @@ export class Storage {
       }
     });
 
+    if (propertiesToUpdate.name === '') {
+      throw new Error(
+        `You can't update the "${placeType}" named "${groundPlace.name}" because the new name defined is empty.`,
+      );
+    }
+
     const newGroundPlace: GroundPlace = {
       ...groundPlace,
       ...propertiesToUpdate,

--- a/src/classes/storage.ts
+++ b/src/classes/storage.ts
@@ -70,6 +70,20 @@ export class Storage {
   }
 
   /**
+   * @description Get the GroundPlaces file.
+   * @returns {GroundPlacesFile}
+   */
+  public getGroundPlacesFile(): GroundPlacesFile {
+    const groundPlaces: GroundPlace[] = cloneDeep(this.getGroundPlaces());
+
+    const groundPlacesFile: GroundPlacesFile = Object.fromEntries(
+      groundPlaces.map(({ gpuid, ...groundPlace }: GroundPlace) => [gpuid, groundPlace]),
+    );
+
+    return groundPlacesFile;
+  }
+
+  /**
    * @description Getter to retrieve the GroundPlaceActionHistory object.
    * @returns {GroundPlaceActionHistory[]}
    */


### PR DESCRIPTION
## Goals of this PR:
- When updating a GroundPlace, check that the new name of the place is not empty.
- Fixed a bug in the autocomplete when the StopGroup and StopCluster filters were activated.
- When initiating a GroundPlacesFile, deleted all the HistoryActions of the instance when they exist.
- New method in the SDK: getGroundPlacesFile - This method retrieves the ground places of the instance in the correct format (like JSON input)