### PR TITLE
fix(global): improve autocomplete, errors messages and add new rules for merging / moving stopgroup

### DIFF
--- a/__tests__/groundplaces/autocomplete.spec.ts
+++ b/__tests__/groundplaces/autocomplete.spec.ts
@@ -172,10 +172,9 @@ describe('#autocomplete', () => {
     ]);
   });
 
-  it('should returns only StopClusters that having SegmentProvider in it and matching strasbourg', () => {
+  it('should returns only StopClusters that matching strasbourg', () => {
     const groundPlacesFiltered: GroundPlace[] = groundPlacesService.autocomplete('strasbourg', [
       AutocompleteFilter.STOP_CLUSTER,
-      AutocompleteFilter.SEGMENT_PROVIDER_STOP,
     ]);
 
     expect(groundPlacesFiltered).toStrictEqual([
@@ -250,68 +249,9 @@ describe('#autocomplete', () => {
     ]);
   });
 
-  it('should returns only StopGroups that having SegmentProvider in it', () => {
-    const groundPlacesFiltered: GroundPlace[] = groundPlacesService.autocomplete('', [
-      AutocompleteFilter.STOP_GROUP,
-      AutocompleteFilter.SEGMENT_PROVIDER_STOP,
-    ]);
-
-    expect(groundPlacesFiltered).toStrictEqual([
-      {
-        gpuid: 'g|FRstrasbou@u0tkru',
-        childs: [
-          {
-            unique_name: null,
-            company_name: 'flixbus',
-            name: 'Strasbourg',
-            latitude: 48.574179,
-            serviced: 'False',
-            company_id: 5,
-            longitude: 7.754266,
-            id: '23',
-          },
-        ],
-        name: 'Strasbourg',
-        longitude: 7.73417,
-        serviced: 'False',
-        has_been_modified: false,
-        warning: false,
-        country_code: 'fr',
-        latitude: 48.58392,
-        is_latest: true,
-        type: 'group',
-      },
-      {
-        gpuid: 'g|FRstraroet@u0tkr3',
-        childs: [
-          {
-            unique_name: null,
-            company_name: 'vsc',
-            name: 'Strasbourg Roethig',
-            latitude: 48.569,
-            serviced: 'False',
-            company_id: 10,
-            longitude: 7.704,
-            id: 'FRBUK',
-          },
-        ],
-        name: 'Strasbourg Roethig',
-        longitude: 7.704,
-        serviced: 'False',
-        has_been_modified: false,
-        warning: false,
-        country_code: 'fr',
-        latitude: 48.569,
-        is_latest: true,
-        type: 'group',
-      },
-    ]);
-  });
-
   it('should returns nothing if the query doesnt matching', () => {
     const groundPlacesFiltered: GroundPlace[] = groundPlacesService.autocomplete('Paris', [
       AutocompleteFilter.STOP_GROUP,
-      AutocompleteFilter.SEGMENT_PROVIDER_STOP,
     ]);
 
     expect(groundPlacesFiltered).toStrictEqual([]);

--- a/__tests__/groundplaces/createStopGroup.spec.ts
+++ b/__tests__/groundplaces/createStopGroup.spec.ts
@@ -85,7 +85,7 @@ describe('#createStopGroup', () => {
     ]);
   });
 
-  it('should throw an error if the new StopGroup is far away from one of its StopCluster parent (beyond 70km)', () => {
+  it('should throw an error if the new StopGroup is far away from its SegmentProviderStop children (beyond 70km)', () => {
     groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
 
     let thrownError: Error;
@@ -107,7 +107,7 @@ describe('#createStopGroup', () => {
 
     expect(thrownError).toEqual(
       new Error(
-        'You can\'t attach the StopGroup with the Gpuid "g|FRstrawolf@y0zh7w" to the StopCluster with the Gpuid "c|FRstrasbou@u0ts2" because they are "6237.92km" away (the limit is 70km).',
+        'You can\'t move the SegmentProviderStop with the ID "19528" inside the StopGroup with the Gpuid "g|FRstrawolf@y0zh7w" because they are "6237.19km" away (the limit is 70km).',
       ),
     );
   });

--- a/__tests__/groundplaces/mergeStopGroup.spec.ts
+++ b/__tests__/groundplaces/mergeStopGroup.spec.ts
@@ -225,4 +225,27 @@ describe('#mergeStopGroup', () => {
 
     expect(thrownError).toEqual(new Error('The StopGroup with the Gpuid "g|FRstrasbou@u0tkruu" is not found.'));
   });
+
+  it('should throw an error if the StopGroup to merge has no childrens', () => {
+    const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+
+    groundPlacesService.init(mockVerylargeGroundPlacesFile as GroundPlacesFile);
+
+    const stopGroupToMergeGpuid = 'g|FRststbi__@u0tkxd';
+    const intoStopGroupGpuid = 'g|FRstrasbou@u0tkru';
+
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.mergeStopGroup(stopGroupToMergeGpuid, intoStopGroupGpuid);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error(
+        'You can\'t merge the StopGroup with the Gpuid "g|FRststbi__@u0tkxd" because it has no SegmentProviderStop childrens.',
+      ),
+    );
+  });
 });

--- a/__tests__/groundplaces/moveSegmentProviderStop.spec.ts
+++ b/__tests__/groundplaces/moveSegmentProviderStop.spec.ts
@@ -1,5 +1,6 @@
 import { GroundPlacesController } from '../../src/classes/groundplaces';
 import * as mockLargeGroundPlacesFile from '../../mocks/largeGroundPlacesFile.json';
+import * as mockVeryLargeGroundPlacesFile from '../../mocks/veryLargeGroundPlacesFile.json';
 import { GroundPlacesFile } from '../../src/types';
 
 describe('#moveSegmentProviderStop', () => {
@@ -201,6 +202,30 @@ describe('#moveSegmentProviderStop', () => {
     expect(thrownError).toEqual(
       new Error(
         'The SegmentProviderStop with the ID "FRBUK" doesn\'t exists inside the StopGroup with the Gpuid "g|FRstrasbou@u0tkru".',
+      ),
+    );
+  });
+
+  it('should throw an error if the new StopGroup parent is already serves by the SegmentProvider of the SegmentProviderStop to move', () => {
+    const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+
+    groundPlacesService.init(mockVeryLargeGroundPlacesFile as GroundPlacesFile);
+
+    const segmentProviderStopId = '23';
+    const fromStopGroupGpuid = 'g|FRstrasbou@u0tkru';
+    const intoStopGroupGpuid = 'g|FRnanvanna@u0skgb';
+
+    let thrownError: Error;
+
+    try {
+      groundPlacesService.moveSegmentProviderStop(segmentProviderStopId, fromStopGroupGpuid, intoStopGroupGpuid);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error(
+        'The SegmentProviderStop ID "23" with the SegmentProvider "flixbus" can\'t be move because the SegmentProvider "flixbus" already exists inside the new StopGroup parent with the Gpuid "g|FRnanvanna@u0skgb".',
       ),
     );
   });

--- a/__tests__/groundplaces/moveSegmentProviderStop.spec.ts
+++ b/__tests__/groundplaces/moveSegmentProviderStop.spec.ts
@@ -1,6 +1,6 @@
 import { GroundPlacesController } from '../../src/classes/groundplaces';
 import * as mockLargeGroundPlacesFile from '../../mocks/largeGroundPlacesFile.json';
-import * as mockVeryLargeGroundPlacesFile from '../../mocks/veryLargeGroundPlacesFile.json';
+import * as mockVeryLargeGroundPlacesFile from '../../mocks/verylargeGroundPlacesFile.json';
 import { GroundPlacesFile } from '../../src/types';
 
 describe('#moveSegmentProviderStop', () => {
@@ -225,7 +225,7 @@ describe('#moveSegmentProviderStop', () => {
 
     expect(thrownError).toEqual(
       new Error(
-        'The SegmentProviderStop ID "23" with the SegmentProvider "flixbus" can\'t be move because the SegmentProvider "flixbus" already exists inside the new StopGroup parent with the Gpuid "g|FRnanvanna@u0skgb".',
+        'The SegmentProviderStop ID "23" can\'t be move because its SegmentProvider ("flixbus") already exists inside the new StopGroup parent with the Gpuid "g|FRnanvanna@u0skgb".',
       ),
     );
   });

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -668,6 +668,12 @@ export class GroundPlacesController {
     try {
       const stopGroupToMerge: StopGroup = this.storageService.getStopGroupByGpuid(stopGroupToMergeGpuid);
 
+      if (!stopGroupToMerge.childs.length) {
+        throw new Error(
+          `You can't merge the StopGroup with the Gpuid "${stopGroupToMergeGpuid}" because it has no SegmentProviderStop childrens.`,
+        );
+      }
+
       stopGroupToMerge.childs.map(({ id: segmentProviderStopId }: SegmentProviderStop) =>
         this.internalMoveSegmentProviderStop(
           segmentProviderStopId,

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -608,10 +608,18 @@ export class GroundPlacesController {
         ({ company_name }: SegmentProviderStop) => company_name === segmentProviderStop.company_name,
       );
 
-      // Check if the SegmentProviderStop to move don't already exist inside the new StopGroup parent specified
+      // Check if the new StopGroup specified is already serves by the SegmentProvider of the SegmentProviderStop to move
       if (isAlreadyBelongToNewStopGroup) {
         throw new Error(
-          `The SegmentProviderStop ID "${segmentProviderStopId}" with the segmentProvider "${segmentProviderStop.company_name}" can't be move because it already exists inside the new StopGroup parent with the Gpuid "${intoStopGroupGpuid}".`,
+          `The SegmentProviderStop ID "${segmentProviderStopId}" with the SegmentProvider "${segmentProviderStop.company_name}" can't be move because the SegmentProvider "${segmentProviderStop.company_name}" already exists inside the new StopGroup parent with the Gpuid "${intoStopGroupGpuid}".`,
+        );
+      }
+
+      const distanceInKm: number = calculateDistanceBetweenTwoPlaceInKm(currentStopGroupParent, newStopGroupParent);
+
+      if (distanceInKm > MAX_DISTANCE_BETWEEN_STOP_GROUP_AND_STOP_CLUSTER_IN_KM) {
+        throw new Error(
+          `You can't move the SegmentProviderStop with the ID "${segmentProviderStopId}" inside the StopGroup with the Gpuid "${intoStopGroupGpuid}" because they are "${distanceInKm}km" away (the limit is ${MAX_DISTANCE_BETWEEN_STOP_GROUP_AND_STOP_CLUSTER_IN_KM}km).`,
         );
       }
 

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -611,7 +611,7 @@ export class GroundPlacesController {
       // Check if the new StopGroup specified is already serves by the SegmentProvider of the SegmentProviderStop to move
       if (isAlreadyBelongToNewStopGroup) {
         throw new Error(
-          `The SegmentProviderStop ID "${segmentProviderStopId}" with the SegmentProvider "${segmentProviderStop.company_name}" can't be move because the SegmentProvider "${segmentProviderStop.company_name}" already exists inside the new StopGroup parent with the Gpuid "${intoStopGroupGpuid}".`,
+          `The SegmentProviderStop ID "${segmentProviderStopId}" can't be move because its SegmentProvider ("${segmentProviderStop.company_name}") already exists inside the new StopGroup parent with the Gpuid "${intoStopGroupGpuid}".`,
         );
       }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,7 +117,6 @@ enum AutocompleteFilter {
   STOP_GROUP = 'stopGroup',
   STOP_CLUSTER = 'stopCluster',
   SERVICED = 'serviced',
-  SEGMENT_PROVIDER_STOP = 'segmentProviderStop',
 }
 
 enum CreateActionHistory {


### PR DESCRIPTION
### `Improvements` 
- Remove the `SegmentProviderStop` filter and added the possibility to find a `StopGroup` from the name of a `SegmentProviderStop`
- Safety on `StopGroup` merge : 
  - It is no longer possible to **merge** a `StopGroup` that does not have children.
  - It is no longer possible to **merge** a `StopGroup` that is too far away from another `StopGroup`
   The `SegmentProviderStop` of the merged `StopGroup` must be within a perimeter of 70km with the new `StopGroup`
 - When **creating** a `StopGroup` from a `SegmentProviderStop`, it is no longer possible to assign a geographical position that exceeds 70km with the `SegmentProviderStop` that was used to **create** the `StopGroup`
 - Updating of some error messages to make them more understandable
 - Adding tests to manage these different use cases
