### PR TITLE
feat: add not_serviced_since field

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,7 @@ interface GroundPlaceBase {
   has_been_modified?: boolean;
   warning?: boolean;
   is_latest?: boolean;
+  not_serviced_since?: string;
 }
 
 interface StopGroupFromFile extends GroundPlaceBase {


### PR DESCRIPTION
Goal: in the master groundPlace file, stopGroups and stopClusters contains the field `not_serviced_since` used in data-processing and must be added to the base groundPlace type

Ex: StopGroup
```
"g|FRseptsaul@u0ep8g":{
    "childs":[{"unique_name":null,"name":"SeptSaulx","company_id":10,"longitude":4.25695,"serviced":"True","company_name":"vsc","latitude":49.15119,"id":"FRBCR"}],
    "name":"SeptSaulx",
    "not_serviced_since":"Na",
    "longitude":4.25695,
    "serviced":"True",
    "has_been_modified":false,
    "warning":true,
    "country_code":"fr",
    "latitude":49.15119,
    "is_latest":true,
    "type":"group"
}
```
Ex: StopCluster
```
   "c|FRbaraquev@spcez":{
      "unique_name":"baraqueville",
      "childs":[
         "g|FRbarcarpe@spcez5"
      ],
      "name":"Baraqueville, Occitanie, France",
      "not_serviced_since":"2019-05-21",
      "longitude":2.42722,
      "serviced":"True",
      "has_been_modified":false,
      "warning":true,
      "country_code":"fr",
      "latitude":44.27059,
      "is_latest":true,
      "type":"cluster"
   }
```