### PR TITLE
fix(createGroundPlace): Add property "is_latest" when creating a new place

### DIFF
--- a/__tests__/groundplaces/applyGroundPlacesActionHistory.spec.ts
+++ b/__tests__/groundplaces/applyGroundPlacesActionHistory.spec.ts
@@ -46,6 +46,7 @@ describe('#applyGroundPlacesActionHistory', () => {
         address: 'Strasbourg, France',
         latitude: 49,
         longitude: 7.8,
+        is_latest: true,
         name: 'Strasbourg, Grand-Nord',
         serviced: 'False',
         type: 'group',

--- a/__tests__/groundplaces/createStopCluster.spec.ts
+++ b/__tests__/groundplaces/createStopCluster.spec.ts
@@ -66,6 +66,7 @@ describe('#createStopCluster', () => {
         name: 'Strasbourg - Wolfisheim',
         longitude: 7.6275127,
         latitude: 48.5857122,
+        is_latest: true,
         type: 'cluster',
         unique_name: null,
       },

--- a/__tests__/groundplaces/createStopGroup.spec.ts
+++ b/__tests__/groundplaces/createStopGroup.spec.ts
@@ -55,6 +55,7 @@ describe('#createStopGroup', () => {
         name: 'Strasbourg - Wolfisheim',
         longitude: 7.6275127,
         latitude: 48.5857122,
+        is_latest: true,
         country_code: 'fr',
         type: 'group',
         serviced: 'False',

--- a/src/helpers/parse.ts
+++ b/src/helpers/parse.ts
@@ -18,6 +18,7 @@ const parseGeneratePlaceToGroundPlace = (generateGpuidGroundPlace: GenerateGpuid
     childs: [],
     serviced: GroundPlaceServiced.FALSE,
     unique_name: generateGpuidGroundPlace.unique_name,
+    is_latest: true,
   };
 
   removeUndefinedValues(newGroundPlace);


### PR DESCRIPTION
This PR aims to add missing property "is_latest" when creating a new place with `createStopGroup` and `createStopCluster`.