### PR TITLE
feat(ground-place-sdk/src/classes/groundplaces): stopCluster name is not in CITY, REGION, COUNTRY format

### DIFF
--- a/__tests__/groundplaces/updateStopCluster.spec.ts
+++ b/__tests__/groundplaces/updateStopCluster.spec.ts
@@ -3,20 +3,20 @@ import * as mockSmallGroundPlacesFile from '../../mocks/smallGroundPlacesFile.js
 import { GroundPlacesFile } from '../../src/types';
 
 describe('#updateStopCluster', () => {
-  it('should not update the name of the StopCluster and throw error', () => {
+  it("should not update the name of the StopCluster and throw error", () => {
     const groundPlacesService: GroundPlacesController = new GroundPlacesController();
     let thrownError: Error;
     groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
 
     try {
-      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', { name: 'Strasbourg, Hauts-de-france; France' });
+      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', { name: 'Strasbourg, Hauts-de-france France' });
     } catch (error) {
       thrownError = error;
     }
 
     expect(thrownError).toEqual(
       new Error(
-        'The StopCluster name you entered (Strasbourg, Hauts-de-france; France) does not respect the following format: CITY, REGION, COUNTRY, please correct!',
+        'The StopCluster name you entered (Strasbourg, Hauts-de-france France) does not respect the following format: CITY, REGION, COUNTRY, please correct!',
       ),
     );
   });

--- a/__tests__/groundplaces/updateStopCluster.spec.ts
+++ b/__tests__/groundplaces/updateStopCluster.spec.ts
@@ -3,6 +3,24 @@ import * as mockSmallGroundPlacesFile from '../../mocks/smallGroundPlacesFile.js
 import { GroundPlacesFile } from '../../src/types';
 
 describe('#updateStopCluster', () => {
+  it('should not update the name of the StopCluster and throw error', () => {
+    const groundPlacesService: GroundPlacesController = new GroundPlacesController();
+    let thrownError: Error;
+    groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
+
+    try {
+      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', { name: 'Strasbourg,Est; France' });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual(
+      new Error(
+        'The StopCluster name you entered (Strasbourg,Est; France) does not respect the following format: CITY, REGION, COUNTRY, please correct!',
+      ),
+    );
+  });
+
   it('should update the name of the StopCluster', () => {
     const groundPlacesService: GroundPlacesController = new GroundPlacesController();
 

--- a/__tests__/groundplaces/updateStopCluster.spec.ts
+++ b/__tests__/groundplaces/updateStopCluster.spec.ts
@@ -9,14 +9,14 @@ describe('#updateStopCluster', () => {
     groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);
 
     try {
-      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', { name: 'Strasbourg,Est; France' });
+      groundPlacesService.updateStopCluster('c|FRstrasbou@u0ts2', { name: 'Strasbourg, Hauts-de-france; France' });
     } catch (error) {
       thrownError = error;
     }
 
     expect(thrownError).toEqual(
       new Error(
-        'The StopCluster name you entered (Strasbourg,Est; France) does not respect the following format: CITY, REGION, COUNTRY, please correct!',
+        'The StopCluster name you entered (Strasbourg, Hauts-de-france; France) does not respect the following format: CITY, REGION, COUNTRY, please correct!',
       ),
     );
   });

--- a/__tests__/groundplaces/updateStopCluster.spec.ts
+++ b/__tests__/groundplaces/updateStopCluster.spec.ts
@@ -3,7 +3,7 @@ import * as mockSmallGroundPlacesFile from '../../mocks/smallGroundPlacesFile.js
 import { GroundPlacesFile } from '../../src/types';
 
 describe('#updateStopCluster', () => {
-  it("should not update the name of the StopCluster and throw error", () => {
+  it('should not update the name of the StopCluster and throw error', () => {
     const groundPlacesService: GroundPlacesController = new GroundPlacesController();
     let thrownError: Error;
     groundPlacesService.init(mockSmallGroundPlacesFile as GroundPlacesFile);

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -335,7 +335,7 @@ export class GroundPlacesController {
       this.storageService.updatePlace(stopClusterGpuid, propertiesToUpdate, GroundPlaceType.CLUSTER);
 
       // If stopCluster name doesn't respect this format: CITY, REGION, COUNTRY
-      const stopClusterNameRegex = /^\w+\,\s*\w+\,\s*\w+$/;
+      const stopClusterNameRegex = /^[a-zA-Z0-9_]+\,\s*[a-zA-Z0-9_]+\,\s*[a-zA-Z0-9_]+$/;
       if (propertiesToUpdate?.name && !stopClusterNameRegex.test(propertiesToUpdate?.name)) {
         throw new Error(
           `The StopCluster name you entered (${propertiesToUpdate?.name}) does not respect the following format: CITY, REGION, COUNTRY, please correct!`,

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -334,6 +334,14 @@ export class GroundPlacesController {
     try {
       this.storageService.updatePlace(stopClusterGpuid, propertiesToUpdate, GroundPlaceType.CLUSTER);
 
+      // If stopCluster name doesn't respect this format: CITY, REGION, COUNTRY
+      const stopClusterNameRegex = /^\w+\,\s*\w+\,\s*\w+$/;
+      if (propertiesToUpdate?.name && !stopClusterNameRegex.test(propertiesToUpdate?.name)) {
+        throw new Error(
+          `The StopCluster name you entered (${propertiesToUpdate?.name}) does not respect the following format: CITY, REGION, COUNTRY, please correct!`,
+        );
+      }
+
       // If latitude and/or longitude have updates wanted, first check that the new distance is correct with all StopGroup childs
       if (propertiesToUpdate.latitude || propertiesToUpdate.longitude) {
         const stopClusterUpdated: StopCluster = this.storageService.getStopClusterByGpuid(stopClusterGpuid);

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -335,7 +335,7 @@ export class GroundPlacesController {
       this.storageService.updatePlace(stopClusterGpuid, propertiesToUpdate, GroundPlaceType.CLUSTER);
 
       // If stopCluster name doesn't respect this format: CITY, REGION, COUNTRY
-      const stopClusterNameRegex = /^[a-zA-Z0-9_]+\,\s*[a-zA-Z0-9_]+\,\s*[a-zA-Z0-9_]+$/;
+      const stopClusterNameRegex = /^[a-zA-Z0-9_-]+\,\s*[a-zA-Z0-9_-]+\,\s*[a-zA-Z0-9_-]+$/;
       if (propertiesToUpdate?.name && !stopClusterNameRegex.test(propertiesToUpdate?.name)) {
         throw new Error(
           `The StopCluster name you entered (${propertiesToUpdate?.name}) does not respect the following format: CITY, REGION, COUNTRY, please correct!`,

--- a/src/classes/groundplaces.ts
+++ b/src/classes/groundplaces.ts
@@ -335,8 +335,7 @@ export class GroundPlacesController {
       this.storageService.updatePlace(stopClusterGpuid, propertiesToUpdate, GroundPlaceType.CLUSTER);
 
       // If stopCluster name doesn't respect this format: CITY, REGION, COUNTRY
-      const stopClusterNameRegex = /^[a-zA-Z0-9_-]+\,\s*[a-zA-Z0-9_-]+\,\s*[a-zA-Z0-9_-]+$/;
-      if (propertiesToUpdate?.name && !stopClusterNameRegex.test(propertiesToUpdate?.name)) {
+      if (propertiesToUpdate?.name && propertiesToUpdate?.name.split(',').length !== 3) {
         throw new Error(
           `The StopCluster name you entered (${propertiesToUpdate?.name}) does not respect the following format: CITY, REGION, COUNTRY, please correct!`,
         );


### PR DESCRIPTION
feat(ground-place-sdk/src/classes/groundplaces): throw error if stopCluster name is not in CITY, REGION, COUNTRY format